### PR TITLE
MODORDERS-233 Add tenantId to cache keys

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -117,26 +117,11 @@ public class TenantReferenceAPI extends TenantAPI {
   public void deleteTenant(Map<String, String> headers, Handler<AsyncResult<Response>> hndlr, Context cntxt) {
     log.info("deleteTenant");
     super.deleteTenant(headers, res -> {
-      if (res.succeeded()) {
         Vertx vertx = cntxt.owner();
         String tenantId = TenantTool.tenantId(headers);
         PostgresClient.getInstance(vertx, tenantId)
-          .closeClient(event -> {
-            if(event.succeeded()) {
-              hndlr.handle(io.vertx.core.Future.succeededFuture(DeleteTenantResponse.respond204()));
-              return;
-            }
-            handleError(hndlr, event);
-          });
-        return;
-      }
-      handleError(hndlr, res);
-
+          .closeClient(event -> hndlr.handle(res));
     }, cntxt);
   }
 
-  private void handleError(Handler<AsyncResult<Response>> hndlr, AsyncResult<?> res) {
-    hndlr.handle(io.vertx.core.Future.succeededFuture(DeleteTenantResponse
-      .respond500WithTextPlain(res.cause().getLocalizedMessage())));
-  }
 }

--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -1,22 +1,21 @@
 package org.folio.rest.impl;
 
+import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.Response;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.TenantLoading;
 import org.folio.rest.tools.utils.TenantTool;
-
-import javax.ws.rs.core.Response;
-import java.util.List;
-import java.util.Map;
-
-import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 
 public class TenantReferenceAPI extends TenantAPI {
   private static final Logger log = LoggerFactory.getLogger(TenantReferenceAPI.class);
@@ -37,6 +36,7 @@ public class TenantReferenceAPI extends TenantAPI {
 
       TenantLoading tl = new TenantLoading();
       boolean loadData = buildDataLoadingParameters(tenantAttributes, tl);
+
       if (loadData) {
         tl.perform(tenantAttributes, headers, vertx, res1 -> {
           if (res1.failed()) {

--- a/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
+++ b/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
@@ -28,8 +28,9 @@ import static org.hamcrest.Matchers.not;
 
 public class TenantSampleDataTest extends TestBase{
 
-  private static final String TEST_EXPECTED_QUANTITY_FOR_ENTRY = "Test expected {} quantity for {}";
   private final Logger logger = LoggerFactory.getLogger(TenantSampleDataTest.class);
+
+  private static final String TEST_EXPECTED_QUANTITY_FOR_ENTRY = "Test expected {} quantity for {}";
 
   private static final Header NONEXISTENT_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "no_tenant");
   private static final Header ANOTHER_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "new_tenant");

--- a/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
+++ b/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
@@ -30,7 +30,6 @@ public class TenantSampleDataTest extends TestBase{
 
   private static final Header NONEXISTENT_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "no_tenant");
   private static final Header ANOTHER_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "new_tenant");
-  private static final Header ANOTHER_TENANT_HEADER_WITHOUT_UPGRADE = new Header(OKAPI_HEADER_TENANT, "no_upgrade_tenant");
   private static final Header PARTIAL_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "partial_tenant");
 
 
@@ -110,19 +109,19 @@ public class TenantSampleDataTest extends TestBase{
     logger.info("load only Reference Data");
     try {
       JsonObject jsonBody = TenantApiTestUtil.prepareTenantBody(false, true);
-      postToTenant(ANOTHER_TENANT_HEADER_WITHOUT_UPGRADE, jsonBody)
+      postToTenant(PARTIAL_TENANT_HEADER, jsonBody)
         .assertThat()
         .statusCode(201);
-      verifyCollectionQuantity("/organizations-storage/categories", 4, ANOTHER_TENANT_HEADER_WITHOUT_UPGRADE);
+      verifyCollectionQuantity("/organizations-storage/categories", 4, PARTIAL_TENANT_HEADER);
       for (TestEntities entity : TestEntities.values()) {
         //category is the only reference data, which must be loaded
         if (!entity.equals(TestEntities.CATEGORY)) {
           logger.info("Test sample data not loaded for " + entity.name());
-          verifyCollectionQuantity(entity.getEndpoint(), 0, ANOTHER_TENANT_HEADER_WITHOUT_UPGRADE);
+          verifyCollectionQuantity(entity.getEndpoint(), 0, PARTIAL_TENANT_HEADER);
         }
       }
     } finally {
-      deleteTenant(ANOTHER_TENANT_HEADER_WITHOUT_UPGRADE);
+      deleteTenant(PARTIAL_TENANT_HEADER);
     }
   }
 

--- a/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
+++ b/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
@@ -7,6 +7,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.jaxrs.model.Organization;
 import org.folio.rest.jaxrs.model.OrganizationCollection;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.utils.TenantApiTestUtil;
 import org.folio.rest.utils.TestEntities;
 import org.junit.Test;
@@ -21,6 +22,8 @@ import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.postToTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 import static org.folio.rest.utils.TestEntities.ORGANIZATION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 
 
 public class TenantSampleDataTest extends TestBase{
@@ -121,7 +124,10 @@ public class TenantSampleDataTest extends TestBase{
         }
       }
     } finally {
+      PostgresClient oldClient = PostgresClient.getInstance(StorageTestSuite.getVertx(), PARTIAL_TENANT_HEADER.getValue());
       deleteTenant(PARTIAL_TENANT_HEADER);
+      PostgresClient newClient = PostgresClient.getInstance(StorageTestSuite.getVertx(), PARTIAL_TENANT_HEADER.getValue());
+      assertThat(oldClient, not(newClient));
     }
   }
 


### PR DESCRIPTION
## Purpose
Fix an error that occurs when rerunning tests folio-org/folio-api-tests#182.

## Approach
- closing DB connection on DELETE /_/tenant

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
