### PR TITLE
MODORGS-42 - Fix log4j/log4j2 configuration conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules/
 /src/main/java/org/folio/rest/jaxrs/*
 /src/main/java/storage/model/*
 /src/main/resources/postgres-conf.json
+/.classpath
+/.project

--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@
               </transformers>
               <filters>
                 <filter>
-                  <artifact>org.folio:raml-module-builder</artifact>
+                  <artifact>org.folio:domain-models*</artifact>
                   <excludes>
                     <exclude>**/log4j2.properties</exclude>
                   </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
               <properties>
                 <property>
                   <name>log4j.configuration</name>
-                  <value>${project.baseUri}src/main/resources/log4j.properties</value>
+                  <value>${project.baseUri}src/main/resources/log4j2.properties</value>
                 </property>
               </properties>
             </configuration>
@@ -415,6 +415,20 @@
                   </manifestEntries>
                 </transformer>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>org.folio:raml-module-builder</artifact>
+                  <excludes>
+                    <exclude>**/log4j2.properties</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/log4j.properties</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
             </configuration>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
-
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20.20C{1} %m%n

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,15 @@
+status = info
+dest = err
+name = PropertiesConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} %-5p [%-25t] %c{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.netty.name = io.netty
+logger.netty.level = info
+logger.netty.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODGOBI-43 Move "Renewals" information to Purchase Order level

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODGOBI-43
 -->
https://issues.folio.org/browse/MODORGS-42

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* remove log4j.properties
* add a log4j2.properties (with level = info) in src/main/resources this will be pulled into the fat jar
* log4j2.properties (with level = info) already lives in src/test/resources and is used during unit tests

Add exclude filters to the shade plugin:
* log4j2.properties from RMB
* log4j.properties from anywhere

Verified `info` level logging works:
```
▶ java -Dhttp.port=8081 -jar target/mod-organizations-storage-fat.jar
starting rest verticle service..........
2019-09-13T15:13:14,394 INFO  [main                     ] Version HV000001: Hibernate Validator 5.2.4.Final
2019-09-13T15:13:14,503 INFO  [main                     ] Messages Loading messages from /infra-messages/APIMessages_de.properties ................................
2019-09-13T15:13:14,504 INFO  [main                     ] Messages Loading messages from /infra-messages/APIMessages_en.properties ................................
2019-09-13T15:13:14,512 INFO  [vert.x-eventloop-thread-0] RestVerticle git: https://github.com/folio-org/raml-module-builder.git a617a1016b0e920786fef3df1baab48a9c0c4829
Attempting to read in the module name from..../Users/vjavalkar/workspace/FOLIO/mod-organizations-storage/target/mod-organizations-storage-fat.jar
2019-09-13T15:13:14,697 INFO  [vert.x-eventloop-thread-0] PomReader module name: mod_organizations_storage, version: 2.2.0
no rules directory found, continuing...
2019-09-13T15:13:14,905 WARN  [vert.x-eventloop-thread-0] AbstractKieModule No files found for KieBase defaultKieBase
2019-09-13T15:13:14,937 INFO  [vert.x-eventloop-thread-0] KieRepositoryImpl KieModule was added: MemoryKieModule[releaseId=org.default:artifact:1.0.0-SNAPSHOT]
2019-09-13T15:13:15,030 INFO  [vert.x-eventloop-thread-0] LogUtil org.folio.rest.RestVerticle start metrics enabled: true
2019-09-13T15:13:15,137 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.OrganizationsStorageUrls class to appropriate urls
2019-09-13T15:13:15,166 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.OrganizationsStorageEmails class to appropriate urls
2019-09-13T15:13:15,170 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.OrganizationsStorageOrganizations class to appropriate urls
2019-09-13T15:13:15,174 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.OrganizationsStorageInterfaces class to appropriate urls
2019-09-13T15:13:15,180 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.OrganizationsStorageAddresses class to appropriate urls
2019-09-13T15:13:15,182 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.OrganizationsStoragePhoneNumbers class to appropriate urls
2019-09-13T15:13:15,184 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.OrganizationsStorageCategories class to appropriate urls
2019-09-13T15:13:15,186 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.OrganizationsStorageContacts class to appropriate urls
2019-09-13T15:13:15,189 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.Rmbtests class to appropriate urls
2019-09-13T15:13:15,193 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.Tenant class to appropriate urls
2019-09-13T15:13:15,194 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.JsonSchemas class to appropriate urls
2019-09-13T15:13:15,194 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.Ramls class to appropriate urls
2019-09-13T15:13:15,195 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.Admin class to appropriate urls
2019-09-13T15:13:15,202 INFO  [vert.x-eventloop-thread-0] AnnotationGrabber Mapping functions in org.folio.rest.jaxrs.resource.Jobs class to appropriate urls
2019-09-13T15:13:15,207 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/organizations-storage/urls
2019-09-13T15:13:15,208 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/organizations-storage/emails
2019-09-13T15:13:15,208 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/organizations-storage/organizations
2019-09-13T15:13:15,208 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/organizations-storage/interfaces
2019-09-13T15:13:15,208 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/organizations-storage/addresses
2019-09-13T15:13:15,209 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/organizations-storage/phone-numbers
2019-09-13T15:13:15,209 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/organizations-storage/categories
2019-09-13T15:13:15,209 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/organizations-storage/contacts
2019-09-13T15:13:15,209 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/rmbtests
2019-09-13T15:13:15,209 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/_/tenant
2019-09-13T15:13:15,209 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/_/jsonSchemas
2019-09-13T15:13:15,209 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/_/ramls
2019-09-13T15:13:15,209 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/admin
2019-09-13T15:13:15,210 INFO  [vert.x-eventloop-thread-0] RestVerticle ^/jobs
2019-09-13T15:13:15,214 INFO  [vert.x-eventloop-thread-0] RestVerticle 1 verticles deployed 
2019-09-13T15:13:15,347 INFO  [vert.x-eventloop-thread-0] RestVerticle init succeeded.......
2019-09-13T15:13:15,436 INFO  [vert.x-eventloop-thread-0] LogUtil org.folio.rest.RestVerticle runPeriodicHook no periodic implementation found, continuing with deployment
2019-09-13T15:13:15,741 INFO  [vert.x-eventloop-thread-0] LogUtil org.folio.rest.RestVerticle runPostDeployHook no Post Deploy Hook implementation found, continuing with deployment
2019-09-13T15:13:15,741 INFO  [vert.x-eventloop-thread-0] LogUtil org.folio.rest.RestVerticle start http server for apis and docs started on port 8081.
2019-09-13T15:13:15,741 INFO  [vert.x-eventloop-thread-0] LogUtil org.folio.rest.RestVerticle start Documentation available at: http://localhost:8081/apidocs/
2019-09-13T15:13:15,742 INFO  [vert.x-eventloop-thread-1] VertxIsolatedDeployer Succeeded in deploying verticle
```

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
