### PR TITLE
MODORGS-47: Add fullTextIndex for 10 organizations fields

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -65,12 +65,6 @@
           "removeAccents": true
         },
         {
-          "fieldName": "name",
-          "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
-        },
-        {
           "fieldName": "code",
           "tOps": "ADD",
           "caseSensitive": false,

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -57,7 +57,13 @@
       "tableName": "organizations",
       "fromModuleVersion": 2.0,
       "withMetadata": true,
-      "ginIndex": [
+      "fullTextIndex": [
+        {
+          "fieldName": "aliases",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
         {
           "fieldName": "name",
           "tOps": "ADD",
@@ -66,6 +72,48 @@
         },
         {
           "fieldName": "code",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "contacts",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "erpCode",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "interfaces",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "language",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "name",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "status",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "taxId",
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true


### PR DESCRIPTION
## Purpose
Avoid warnings about missing full text indexes.

## Approach
Add indexes for the 10 fields mentioned in MODORG-47.

#### TODOS and Open Questions
Consider updating RMB to latest version and using the `@`-relation modifiers for array searches:
https://github.com/folio-org/raml-module-builder#cql--relation-modifiers-for-array-searches