### PR TITLE
MODORGS-61 - Release 2.2.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 ## 2.3.0 - Unreleased
 
+## 2.2.2 - Released
+Bugfix release to fix issues with migration script
+
+[Full Changelog](https://github.com/folio-org/mod-organizations-storage/compare/v2.2.1...v2.2.2)
+
+### Bug Fixes
+* [MODORGS-59](https://issues.folio.org/browse/MODORGS-59) New full text indexes not being created
+
 ## 2.2.1 - Released
 Bugfix release to support filtering by Vendor=No in Organizations
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-organizations-storage</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+  <version>2.2.2</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -466,7 +466,7 @@
     <url>https://github.com/folio-org/mod-organizations-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-organizations-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-organizations-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.2.2</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-organizations-storage</artifactId>
-  <version>2.2.2</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -466,7 +466,7 @@
     <url>https://github.com/folio-org/mod-organizations-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-organizations-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-organizations-storage.git</developerConnection>
-    <tag>v2.2.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -56,7 +56,7 @@
     {
       "tableName": "organizations",
       "customSnippetPath": "migration/organizations.sql",
-      "fromModuleVersion": "mod-organizations-storage-2.0.0",
+      "fromModuleVersion": "mod-organizations-storage-2.2.2",
       "withMetadata": true,
       "fullTextIndex": [
         {


### PR DESCRIPTION
MODORGS-61 - Release 2.2.2

Bug fix release for fixing issues with migration script (fullTextIndexes weren't created).