### PR TITLE
Fix for API tests (missing schemas path)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <aspectj.version>1.9.4</aspectj.version>
     <module_name>mod-organizations-storage</module_name>
     <http.port>8081</http.port>
-    <jsonschema_paths>acq-models/mod-orgs/schemas,raml-util/schemas</jsonschema_paths>
+    <jsonschema_paths>acq-models/mod-orgs/schemas,raml-util/schemas,acq-models/common/schemas</jsonschema_paths>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
     <raml-module-builder.version>29.3.0</raml-module-builder.version>


### PR DESCRIPTION
These pom.xml changes fix API mod-organization-storage API tests failure when uuid.json schema wasn't resolved by schemas validator.

Verified locally:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/42964285/81931695-2d6e0d00-95f3-11ea-9e95-733a58dd27d5.png">
