### PR TITLE
MODORGSTOR-74: Update to RMB 30.2.4 fixing public.gin_trgm_ops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <jsonschema_paths>acq-models/mod-orgs/schemas,raml-util/schemas,acq-models/common/schemas</jsonschema_paths>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>30.0.1</raml-module-builder.version>
+    <raml-module-builder.version>30.2.4</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <postgres.driver.version>9.4.1212</postgres.driver.version>
   </properties>
@@ -34,13 +34,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.10.2</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -56,10 +56,6 @@ public class StorageTestSuite {
 
     vertx = Vertx.vertx();
 
-    logger.info("Start embedded database");
-    PostgresClient.setIsEmbedded(true);
-    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
-
     DeploymentOptions options = new DeploymentOptions();
 
     options.setConfig(new JsonObject().put("http.port", port).put(HttpClientMock2.MOCK_MODE, "true"));


### PR DESCRIPTION
Don't pin jackson version, RMB and Vert.x ship with latest version.
(Side note: Vert.x BOM should be preferred over jackson BOM, see
https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-300 ).

For unit tests let RMB decide whether to start embedded postgres, see
https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-26