### PR TITLE
[MODORGSTOR-112] Make one organization address primary

### DIFF
--- a/src/main/resources/templates/db_scripts/make_one_address_primary.sql
+++ b/src/main/resources/templates/db_scripts/make_one_address_primary.sql
@@ -1,0 +1,6 @@
+-- Set the first address as primary when an organization does not have any primary address
+UPDATE ${myuniversity}_${mymodule}.organizations
+SET
+  jsonb = jsonb_set(jsonb, '{addresses, 0, isPrimary}', 'true')
+WHERE
+  jsonb_array_length(jsonb -> 'addresses') > 0 AND NOT jsonb -> 'addresses' @> '[{"isPrimary":true}]';


### PR DESCRIPTION
## Purpose
[MODORGSTOR-112](https://issues.folio.org/browse/MODORGSTOR-112)

## Approach
Created a new SQL script (not a migration) which looks for organizations that have addresses but no primary address, and sets the first address as the primary.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
