### PR TITLE
MODORG-50. Organizations app shows only 20k records as total when the actual number is much higher

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,5 +1,5 @@
 {
-  "exactCount" : 20000,
+  "exactCount" : 80000,
   "scripts": [
     {
       "run": "after",


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORG-50
In scope of testing 73k organizations was created:

With exactCount = 20000 results are:
**Get all active orgs: 920ms - 1.1s**
Get all inactive orgs: 711ms
Get all pendings orgs(No results found): 718ms
**Paginated call: 944ms - 1.01s**
Get org by id: 419ms-515ms

 
With exactCount = 80000 results are:
**Get all active orgs: 1.04s - 1.2s**
Get all inactive orgs: 712ms
Get all pendings orgs(No results found): 795ms
**Paginated call: 1.2s - 1.34s**
Get org by id: 455ms

![image](https://github.com/folio-org/mod-organizations-storage/assets/25097693/02ed576c-45c7-441a-8c3b-709bd0868d1c)
