### PR TITLE
[MODORDSTOR-380] Implement CRUD for Settings API

### DIFF
--- a/ramls/setting.raml
+++ b/ramls/setting.raml
@@ -5,11 +5,11 @@ version: v1.0
 
 documentation:
   - title: Settings
-    content: <b>CRUD APIs used to manage settings.</b>
+    content: <b>CRUD APIs used to manage settings for mod-organizations.</b>
 
 types:
-  setting: !include acq-models/mod-orgs/schemas/setting.json
-  setting_collection: !include acq-models/mod-orgs/schemas/setting_collection.json
+  setting: !include acq-models/common/schemas/setting.json
+  setting_collection: !include acq-models/common/schemas/setting_collection.json
   errors: !include raml-util/schemas/errors.schema
   UUID:
     type: string
@@ -29,15 +29,15 @@ resourceTypes:
 /organizations-storage/settings:
   type:
     collection-get:
-      exampleCollection: !include acq-models/mod-orgs/examples/setting_collection.sample
-      exampleItem: !include acq-models/mod-orgs/examples/setting_post.sample
+      exampleCollection: !include acq-models/common/examples/setting_collection.sample
+      exampleItem: !include acq-models/common/examples/setting_post.sample
       schemaCollection: setting_collection
       schemaItem: setting
   get:
     description: Get a list of settings
     is: [
-        searchable: { description: "CQL query", example: "key=BANKING_INFORMATION_ENABLED" },
-        pageable
+      searchable: { description: "CQL query", example: "key=BANKING_INFORMATION_ENABLED" },
+      pageable
     ]
   /{id}:
     uriParameters:
@@ -46,7 +46,7 @@ resourceTypes:
         type: UUID
     type:
       collection-item-get:
-        exampleItem: !include acq-models/mod-orgs/examples/setting_get.sample
+        exampleItem: !include acq-models/common/examples/setting_get.sample
         schema: setting
     put:
       description: Update a setting by id
@@ -55,7 +55,7 @@ resourceTypes:
         application/json:
           example:
             strict: false
-            value: !include acq-models/mod-orgs/examples/setting_post.sample
+            value: !include acq-models/common/examples/setting_post.sample
           type: setting
       responses:
         204:


### PR DESCRIPTION
## Purpose
[[MODORDSTOR-380] Implement CRUD for Settings API](https://folio-org.atlassian.net/browse/MODORDSTOR-380)

## Approach
* Change settings.raml to use settings schemas from new location
