### PR TITLE
Add POST and DELETE methods to settings API

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -365,12 +365,17 @@
     },
     {
       "id": "organizations-storage.settings",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],
           "pathPattern": "/organizations-storage/settings",
           "permissionsRequired": ["organizations-storage.settings.collection.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/organizations-storage/settings",
+          "permissionsRequired": ["organizations-storage.settings.item.post"]
         },
         {
           "methods": ["GET"],
@@ -381,6 +386,11 @@
           "methods": ["PUT"],
           "pathPattern": "/organizations-storage/settings/{id}",
           "permissionsRequired": ["organizations-storage.settings.item.put"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/organizations-storage/settings/{id}",
+          "permissionsRequired": ["organizations-storage.settings.item.delete"]
         }
       ]
     },
@@ -939,6 +949,11 @@
       "description" : "Get a collection of settings"
     },
     {
+      "permissionName" : "organizations-storage.settings.item.post",
+      "displayName" : "setting post",
+      "description" : "Create a setting"
+    },
+    {
       "permissionName" : "organizations-storage.settings.item.get",
       "displayName" : "setting get",
       "description" : "Fetch a setting"
@@ -949,13 +964,20 @@
       "description" : "Update a setting"
     },
     {
+      "permissionName" : "organizations-storage.settings.item.delete",
+      "displayName" : "setting delete",
+      "description" : "Delete a setting"
+    },
+    {
       "permissionName" : "organizations-storage.settings.all",
       "displayName" : "setting all",
       "description" : "All permissions for setting",
       "subPermissions" : [
         "organizations-storage.settings.collection.get",
+        "organizations-storage.settings.item.post",
         "organizations-storage.settings.item.get",
-        "organizations-storage.settings.item.put"
+        "organizations-storage.settings.item.put",
+        "organizations-storage.settings.item.delete"
       ]
     },
     {

--- a/ramls/setting.raml
+++ b/ramls/setting.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Settings"
 baseUri: https://github.com/folio-org/mod-organizations-storage
-version: v1.0
+version: v1.1
 
 documentation:
   - title: Settings
@@ -22,13 +22,13 @@ traits:
   validate: !include raml-util/traits/validation.raml
 
 resourceTypes:
-  collection-get: !include raml-util/rtypes/collection-get.raml
-  collection-item-get: !include raml-util/rtypes/item-collection-get.raml
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
 
 
 /organizations-storage/settings:
   type:
-    collection-get:
+    collection:
       exampleCollection: !include acq-models/common/examples/setting_collection.sample
       exampleItem: !include acq-models/common/examples/setting_post.sample
       schemaCollection: setting_collection
@@ -45,7 +45,7 @@ resourceTypes:
         description: The UUID of a setting
         type: UUID
     type:
-      collection-item-get:
+      collection-item:
         exampleItem: !include acq-models/common/examples/setting_get.sample
         schema: setting
     put:

--- a/src/main/java/org/folio/rest/impl/OrganizationSettingsAPI.java
+++ b/src/main/java/org/folio/rest/impl/OrganizationSettingsAPI.java
@@ -33,12 +33,32 @@ public class OrganizationSettingsAPI implements OrganizationsStorageSettings {
 
   @Override
   @Validate
+  public void postOrganizationsStorageSettings(Setting entity,
+                                               Map<String, String> okapiHeaders,
+                                               Handler<AsyncResult<Response>> asyncResultHandler,
+                                               Context vertxContext) {
+    PgUtil.post(SETTINGS_TABLE, entity, okapiHeaders, vertxContext, PostOrganizationsStorageSettingsResponse.class,
+      asyncResultHandler);
+  }
+
+  @Override
+  @Validate
   public void getOrganizationsStorageSettingsById(String id,
                                                   Map<String, String> okapiHeaders,
                                                   Handler<AsyncResult<Response>> asyncResultHandler,
                                                   Context vertxContext) {
     PgUtil.getById(SETTINGS_TABLE, Setting.class, id, okapiHeaders, vertxContext,
       GetOrganizationsStorageSettingsByIdResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  @Validate
+  public void deleteOrganizationsStorageSettingsById(String id,
+                                                     Map<String, String> okapiHeaders,
+                                                     Handler<AsyncResult<Response>> asyncResultHandler,
+                                                     Context vertxContext) {
+    PgUtil.deleteById(SETTINGS_TABLE, id, okapiHeaders, vertxContext,
+      DeleteOrganizationsStorageSettingsByIdResponse.class, asyncResultHandler);
   }
 
   @Override


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORGSTOR-173

## Purpose
Add `POST` and `DELETE` methods to settings API so consumers can create and delete settings.

## Approach
* Updated API definition in `setting.raml` and added method implementations to `OrganizationSettingsAPI.java`.
* Updated permissions
* Updated `OrganizationSettingsTest.java` to include invocations of `POST` and `DELETE` endpoints
* Added new permissions
* Increased minor interface version

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code are 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
