### PR TITLE
[MODORG-34] Migration: Remove categories that are not UUIDs

### DIFF
--- a/src/main/resources/templates/db_scripts/migration/uuid_categories.ftl
+++ b/src/main/resources/templates/db_scripts/migration/uuid_categories.ftl
@@ -1,0 +1,65 @@
+-- Remove categories that are not UUIDs before changing the type
+
+<#if mode.name() == "UPDATE">
+
+UPDATE ${myuniversity}_${mymodule}.contacts
+SET jsonb = jsonb || jsonb_build_object(
+  'addresses',
+  CASE WHEN jsonb->'addresses' IS NULL OR jsonb_array_length(jsonb->'addresses') = 0 THEN '[]' ELSE
+    (SELECT jsonb_agg(
+      jsonb_set(addresses, '{categories}', jsonb_path_query_array(addresses, '$.categories[*] ? (@ like_regex "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")'))
+    ) FROM jsonb_array_elements(jsonb->'addresses') AS addresses)
+  END,
+  'phoneNumbers',
+  CASE WHEN jsonb->'phoneNumbers' IS NULL OR jsonb_array_length(jsonb->'phoneNumbers') = 0 THEN '[]' ELSE
+    (SELECT jsonb_agg(
+      jsonb_set(phoneNumbers, '{categories}', jsonb_path_query_array(phoneNumbers, '$.categories[*] ? (@ like_regex "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")'))
+    ) FROM jsonb_array_elements(jsonb->'phoneNumbers') AS phoneNumbers)
+  END,
+  'emails',
+  CASE WHEN jsonb->'emails' IS NULL OR jsonb_array_length(jsonb->'emails') = 0 THEN '[]' ELSE
+    (SELECT jsonb_agg(
+      jsonb_set(emails, '{categories}', jsonb_path_query_array(emails, '$.categories[*] ? (@ like_regex "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")'))
+    ) FROM jsonb_array_elements(jsonb->'emails') AS emails)
+  END,
+  'urls',
+  CASE WHEN jsonb->'urls' IS NULL OR jsonb_array_length(jsonb->'urls') = 0 THEN '[]' ELSE
+    (SELECT jsonb_agg(
+      jsonb_set(urls, '{categories}', jsonb_path_query_array(urls, '$.categories[*] ? (@ like_regex "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")'))
+    ) FROM jsonb_array_elements(jsonb->'urls') AS urls)
+  END,
+  'categories',
+  CASE WHEN jsonb->'categories' IS NULL OR jsonb_array_length(jsonb->'categories') = 0 THEN '[]' ELSE
+    jsonb_path_query_array(jsonb, '$.categories[*] ? (@ like_regex "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")')
+  END
+);
+
+UPDATE ${myuniversity}_${mymodule}.organizations
+SET jsonb = jsonb || jsonb_build_object(
+  'addresses',
+  CASE WHEN jsonb->'addresses' IS NULL OR jsonb_array_length(jsonb->'addresses') = 0 THEN '[]' ELSE
+    (SELECT jsonb_agg(
+      jsonb_set(addresses, '{categories}', jsonb_path_query_array(addresses, '$.categories[*] ? (@ like_regex "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")'))
+    ) FROM jsonb_array_elements(jsonb->'addresses') AS addresses)
+  END,
+  'phoneNumbers',
+  CASE WHEN jsonb->'phoneNumbers' IS NULL OR jsonb_array_length(jsonb->'phoneNumbers') = 0 THEN '[]' ELSE
+    (SELECT jsonb_agg(
+      jsonb_set(phoneNumbers, '{categories}', jsonb_path_query_array(phoneNumbers, '$.categories[*] ? (@ like_regex "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")'))
+    ) FROM jsonb_array_elements(jsonb->'phoneNumbers') AS phoneNumbers)
+  END,
+  'emails',
+  CASE WHEN jsonb->'emails' IS NULL OR jsonb_array_length(jsonb->'emails') = 0 THEN '[]' ELSE
+    (SELECT jsonb_agg(
+      jsonb_set(emails, '{categories}', jsonb_path_query_array(emails, '$.categories[*] ? (@ like_regex "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")'))
+    ) FROM jsonb_array_elements(jsonb->'emails') AS emails)
+  END,
+  'urls',
+  CASE WHEN jsonb->'urls' IS NULL OR jsonb_array_length(jsonb->'urls') = 0 THEN '[]' ELSE
+    (SELECT jsonb_agg(
+      jsonb_set(urls, '{categories}', jsonb_path_query_array(urls, '$.categories[*] ? (@ like_regex "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")'))
+    ) FROM jsonb_array_elements(jsonb->'urls') AS urls)
+  END
+);
+
+</#if>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -37,7 +37,7 @@
       "fromModuleVersion": "mod-organizations-storage-4.9.0"
     },
     {
-      "run": "before",
+      "run": "after",
       "snippetPath": "migration/uuid_categories.ftl",
       "fromModuleVersion": "mod-organizations-storage-5.0.0"
     }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -35,6 +35,11 @@
       "run": "after",
       "snippetPath": "tables/create_internal_lock_table.sql",
       "fromModuleVersion": "mod-organizations-storage-4.9.0"
+    },
+    {
+      "run": "before",
+      "snippetPath": "migration/uuid_categories.ftl",
+      "fromModuleVersion": "mod-organizations-storage-5.0.0"
     }
   ],
   "tables": [


### PR DESCRIPTION
## Purpose
[MODORG-34](https://folio-org.atlassian.net/browse/MODORG-34) - json schema for categories defines type string but folio actually requires UUID

## Approach
Migration script removing categories that are not UUIDs in contacts and organizations.
Note: the implementation assumes the "categories" key exists within array items even though it is not enforced by the schema. Saving with RMB does create the key with an empty array if none is defined.

## Learning
Updating items within arrays within arrays in a json is not simple. It is much easier to migrate relational databases.

[Related acq-models PR](https://github.com/folio-org/acq-models/pull/516) - [mod-organizations PR](https://github.com/folio-org/mod-organizations/pull/73)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code are 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
