### PR TITLE
[MODORG-84]. ECS - Create reference organizations for each tenant

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -24,6 +24,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 public class TenantReferenceAPI extends TenantAPI {
+
   private static final Logger log = LogManager.getLogger(TenantReferenceAPI.class);
   private static final String PARAMETER_LOAD_SAMPLE = "loadSample";
   private static final String PARAMETER_LOAD_REFERENCE = "loadReference";
@@ -53,30 +54,38 @@ public class TenantReferenceAPI extends TenantAPI {
     if (isLoadSample(tenantAttributes)) {
       if (isNew(tenantAttributes, "3.2.0")) {
         tl.withKey(PARAMETER_LOAD_SAMPLE)
-        .withLead("data")
-        .add("organizations-3.2.0", "organizations-storage/organizations");
+          .withLead("data")
+          .add("organizations-3.2.0", "organizations-storage/organizations");
       }
       if (isNew(tenantAttributes, "1.1.0")) {
         tl.withKey(PARAMETER_LOAD_SAMPLE)
-        .withLead("data")
-        .add("contacts-1.1.0", "organizations-storage/contacts");
+          .withLead("data")
+          .add("contacts-1.1.0", "organizations-storage/contacts");
       }
       if (isNew(tenantAttributes, "2.0.0")) {
         tl.withKey(PARAMETER_LOAD_SAMPLE)
-        .withLead("data")
-        .add("interfaces-2.0.0", "organizations-storage/interfaces");
+          .withLead("data")
+          .add("interfaces-2.0.0", "organizations-storage/interfaces");
       }
     }
     if (isLoadReference(tenantAttributes)) {
       if (isNew(tenantAttributes, "1.0.0")) {
         tl.withKey(PARAMETER_LOAD_REFERENCE)
-        .withLead("data")
-        .add("categories-1.0.0", "organizations-storage/categories");
+          .withLead("data")
+          .add("categories-1.0.0", "organizations-storage/categories");
       }
       if (isNew(tenantAttributes, "4.3.0")) {
         tl.withKey(PARAMETER_LOAD_REFERENCE)
-        .withLead("data")
-        .add("organization_types-4.3.0", "organizations-storage/organization-types");
+          .withLead("data")
+          .add("organization_types-4.3.0", "organizations-storage/organization-types");
+      }
+      if (isNew(tenantAttributes, "5.0.0")) {
+        tl.withKey(PARAMETER_LOAD_REFERENCE)
+          .withLead("data")
+          .add("privileged-contacts-5.0.0", "organizations-storage/privileged-contacts");
+        tl.withKey(PARAMETER_LOAD_REFERENCE)
+          .withLead("data")
+          .add("organizations-5.0.0", "organizations-storage/organizations");
       }
     }
   }

--- a/src/main/resources/data/organizations-5.0.0/cac.json
+++ b/src/main/resources/data/organizations-5.0.0/cac.json
@@ -1,0 +1,68 @@
+{
+  "id": "b3351a99-25aa-40c7-9a33-be73aa6ed341",
+  "edi": {
+    "ediFtp": {
+      "ftpMode": "ASCII",
+      "ftpFormat": "SFTP",
+      "ftpConnMode": "Active"
+    },
+    "libEdiType": "31B/US-SAN",
+    "vendorEdiType": "31B/US-SAN"
+  },
+  "code": "CAC",
+  "name": "Cruise Acoustics",
+  "urls": [],
+  "emails": [],
+  "status": "Active",
+  "aliases": [],
+  "isDonor": false,
+  "accounts": [
+    {
+      "name": "Operations Account",
+      "accountNo": "OA547891",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    },
+    {
+      "name": "Marketing Fund",
+      "accountNo": "MF123789",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    }
+  ],
+  "contacts": [],
+  "isVendor": true,
+  "metadata": {
+    "createdDate": "2025-07-18T11:03:20.306Z",
+    "updatedDate": "2025-07-18T11:38:19.869Z",
+    "createdByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8",
+    "updatedByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8"
+  },
+  "addresses": [
+    {
+      "isPrimary": true,
+      "categories": [],
+      "addressLine1": "875 Ocean Drive",
+      "addressLine2": "Unit 1420",
+      "city": "Miami Beach",
+      "stateRegion": "FL",
+      "zipCode": "33139",
+      "country": "USA"
+    }
+  ],
+  "acqUnitIds": [],
+  "agreements": [],
+  "changelogs": [],
+  "interfaces": [],
+  "phoneNumbers": [],
+  "paymentMethod": "Electronic Transfer",
+  "discountPercent": 12.25,
+  "vendorCurrencies": [
+    "USD",
+    "EUR",
+    "JPY"
+  ],
+  "organizationTypes": [],
+  "exportToAccounting": false,
+  "privilegedContacts": []
+}

--- a/src/main/resources/data/organizations-5.0.0/gld.json
+++ b/src/main/resources/data/organizations-5.0.0/gld.json
@@ -1,0 +1,69 @@
+{
+  "id": "7c2d0697-b619-40ab-9b6f-590e6964daa8",
+  "edi": {
+    "ediFtp": {
+      "ftpMode": "ASCII",
+      "ftpFormat": "SFTP",
+      "ftpConnMode": "Active"
+    },
+    "libEdiType": "31B/US-SAN",
+    "vendorEdiType": "31B/US-SAN"
+  },
+  "code": "GLD",
+  "name": "Gold Limited",
+  "urls": [],
+  "emails": [],
+  "status": "Active",
+  "aliases": [],
+  "isDonor": false,
+  "accounts": [
+    {
+      "name": "Premium Trading",
+      "accountNo": "PT789012",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    },
+    {
+      "name": "International Sales",
+      "accountNo": "IS456789",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    }
+  ],
+  "contacts": [],
+  "isVendor": true,
+  "metadata": {
+    "createdDate": "2025-07-18T10:42:28.220Z",
+    "updatedDate": "2025-07-18T11:38:02.072Z",
+    "createdByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8",
+    "updatedByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8"
+  },
+  "addresses": [
+    {
+      "isPrimary": true,
+      "categories": [],
+      "addressLine1": "123 Gold Street",
+      "addressLine2": "Floor 15",
+      "city": "Chicago",
+      "stateRegion": "IL",
+      "zipCode": "60601",
+      "country": "USA"
+    }
+  ],
+  "acqUnitIds": [],
+  "agreements": [],
+  "changelogs": [],
+  "interfaces": [],
+  "phoneNumbers": [],
+  "paymentMethod": "International Wire",
+  "discountPercent": 18.5,
+  "vendorCurrencies": [
+    "EUR",
+    "GBP",
+    "CHF",
+    "USD"
+  ],
+  "organizationTypes": [],
+  "exportToAccounting": false,
+  "privilegedContacts": []
+}

--- a/src/main/resources/data/organizations-5.0.0/gnt.json
+++ b/src/main/resources/data/organizations-5.0.0/gnt.json
@@ -1,0 +1,70 @@
+{
+  "id": "c428b467-7cec-45e1-8f8a-9a46d00181ff",
+  "edi": {
+    "ediFtp": {
+      "ftpMode": "ASCII",
+      "ftpFormat": "SFTP",
+      "ftpConnMode": "Active"
+    },
+    "libEdiType": "31B/US-SAN",
+    "vendorEdiType": "31B/US-SAN"
+  },
+  "code": "GNT",
+  "name": "Gnome Technologies",
+  "urls": [],
+  "emails": [],
+  "status": "Active",
+  "aliases": [],
+  "isDonor": false,
+  "accounts": [
+    {
+      "name": "Tech Solutions",
+      "accountNo": "TS951753",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    },
+    {
+      "name": "Research Division",
+      "accountNo": "RD357159",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    }
+  ],
+  "contacts": [],
+  "isVendor": true,
+  "metadata": {
+    "createdDate": "2025-07-18T11:18:42.399Z",
+    "updatedDate": "2025-07-18T11:40:02.979Z",
+    "createdByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8",
+    "updatedByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8"
+  },
+  "addresses": [
+    {
+      "isPrimary": true,
+      "categories": [],
+      "addressLine1": "987 Innovation Park",
+      "addressLine2": "Building C",
+      "city": "San Jose",
+      "stateRegion": "CA",
+      "zipCode": "95110",
+      "country": "USA"
+    }
+  ],
+  "acqUnitIds": [],
+  "agreements": [],
+  "changelogs": [],
+  "interfaces": [],
+  "phoneNumbers": [],
+  "paymentMethod": "ACH Transfer",
+  "discountPercent": 22.5,
+  "claimingInterval": 45,
+  "vendorCurrencies": [
+    "USD",
+    "EUR",
+    "JPY",
+    "GBP"
+  ],
+  "organizationTypes": [],
+  "exportToAccounting": false,
+  "privilegedContacts": []
+}

--- a/src/main/resources/data/organizations-5.0.0/jas.json
+++ b/src/main/resources/data/organizations-5.0.0/jas.json
@@ -1,0 +1,64 @@
+{
+  "id": "7df72a2b-cdc7-419f-80ff-7f6ab349fd34",
+  "edi": {
+    "ediFtp": {
+      "ftpMode": "ASCII",
+      "ftpFormat": "SFTP",
+      "ftpConnMode": "Active"
+    },
+    "libEdiType": "31B/US-SAN",
+    "vendorEdiType": "31B/US-SAN"
+  },
+  "code": "JAS",
+  "name": "James, Ada",
+  "urls": [],
+  "emails": [],
+  "status": "Active",
+  "aliases": [],
+  "isDonor": true,
+  "accounts": [
+    {
+      "name": "Research Fund",
+      "accountNo": "RF982365",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    }
+  ],
+  "contacts": [],
+  "isVendor": false,
+  "metadata": {
+    "createdDate": "2025-07-18T11:28:50.782Z",
+    "updatedDate": "2025-07-18T11:39:22.585Z",
+    "createdByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8",
+    "updatedByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8"
+  },
+  "addresses": [
+    {
+      "isPrimary": true,
+      "categories": [],
+      "addressLine1": "1234 Pine Avenue",
+      "addressLine2": "Floor 5",
+      "city": "Portland",
+      "stateRegion": "OR",
+      "zipCode": "97201",
+      "country": "USA"
+    }
+  ],
+  "acqUnitIds": [],
+  "agreements": [],
+  "changelogs": [],
+  "interfaces": [],
+  "phoneNumbers": [],
+  "vendorCurrencies": [
+    "USD",
+    "CAD"
+  ],
+  "organizationTypes": [],
+  "exportToAccounting": false,
+  "privilegedContacts": [
+    "b1b56c53-23a6-46f9-af2d-80921efcf84f"
+  ],
+  "paymentMethod": "Bank Transfer",
+  "discountPercent": 8.75
+}
+

--- a/src/main/resources/data/organizations-5.0.0/lop.json
+++ b/src/main/resources/data/organizations-5.0.0/lop.json
@@ -1,0 +1,62 @@
+{
+  "id": "edafbc2c-60fc-4633-ba4b-81d36ed65a78",
+  "edi": {
+    "ediFtp": {
+      "ftpMode": "ASCII",
+      "ftpFormat": "SFTP",
+      "ftpConnMode": "Active"
+    },
+    "libEdiType": "31B/US-SAN",
+    "vendorEdiType": "31B/US-SAN"
+  },
+  "code": "LOP",
+  "name": "Lopez, Cheryl",
+  "urls": [],
+  "emails": [],
+  "status": "Active",
+  "aliases": [],
+  "isDonor": true,
+  "accounts": [
+    {
+      "name": "Donation Fund",
+      "accountNo": "DF456123",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    }
+  ],
+  "contacts": [],
+  "isVendor": false,
+  "metadata": {
+    "createdDate": "2025-07-18T11:29:52.185Z",
+    "updatedDate": "2025-07-18T11:39:14.148Z",
+    "createdByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8",
+    "updatedByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8"
+  },
+  "addresses": [
+    {
+      "isPrimary": true,
+      "categories": [],
+      "addressLine1": "543 Elm Street",
+      "addressLine2": "Apt 7B",
+      "city": "Seattle",
+      "stateRegion": "WA",
+      "zipCode": "98101",
+      "country": "USA"
+    }
+  ],
+  "acqUnitIds": [],
+  "agreements": [],
+  "changelogs": [],
+  "interfaces": [],
+  "phoneNumbers": [],
+  "vendorCurrencies": [
+    "USD"
+  ],
+  "organizationTypes": [],
+  "exportToAccounting": false,
+  "privilegedContacts": [
+    "f2b56c53-23a6-46f9-af2d-80921efcf85e"
+  ],
+  "paymentMethod": "Wire Transfer",
+  "discountPercent": 5.75
+}

--- a/src/main/resources/data/organizations-5.0.0/qco.json
+++ b/src/main/resources/data/organizations-5.0.0/qco.json
@@ -1,0 +1,69 @@
+{
+  "id": "d4fde8d9-24b2-4bea-8c7b-bebb01e99e8c",
+  "edi": {
+    "ediFtp": {
+      "ftpMode": "ASCII",
+      "ftpFormat": "SFTP",
+      "ftpConnMode": "Active"
+    },
+    "libEdiType": "31B/US-SAN",
+    "vendorEdiType": "31B/US-SAN"
+  },
+  "code": "QCO",
+  "name": "Quad Corporation",
+  "urls": [],
+  "emails": [],
+  "status": "Active",
+  "aliases": [],
+  "isDonor": false,
+  "accounts": [
+    {
+      "name": "Corporate Services",
+      "accountNo": "CS852147",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    },
+    {
+      "name": "Innovation Lab",
+      "accountNo": "IL741963",
+      "acqUnitIds": [],
+      "accountStatus": "Pending"
+    }
+  ],
+  "contacts": [],
+  "isVendor": true,
+  "metadata": {
+    "createdDate": "2025-07-18T11:04:37.832Z",
+    "updatedDate": "2025-07-18T11:38:28.788Z",
+    "createdByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8",
+    "updatedByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8"
+  },
+  "addresses": [
+    {
+      "isPrimary": true,
+      "categories": [],
+      "addressLine1": "456 Tech Boulevard",
+      "addressLine2": "Suite 800",
+      "city": "Boston",
+      "stateRegion": "MA",
+      "zipCode": "02108",
+      "country": "USA"
+    }
+  ],
+  "acqUnitIds": [],
+  "agreements": [],
+  "changelogs": [],
+  "interfaces": [],
+  "phoneNumbers": [],
+  "paymentMethod": "EFT",
+  "discountPercent": 14.75,
+  "claimingInterval": 25,
+  "vendorCurrencies": [
+    "USD",
+    "CAD",
+    "AUD"
+  ],
+  "organizationTypes": [],
+  "exportToAccounting": false,
+  "privilegedContacts": []
+}

--- a/src/main/resources/data/organizations-5.0.0/slm.json
+++ b/src/main/resources/data/organizations-5.0.0/slm.json
@@ -1,0 +1,68 @@
+{
+  "id": "9304bb1e-cbfb-4db8-a1ca-2c16079f0a3d",
+  "edi": {
+    "ediFtp": {
+      "ftpMode": "ASCII",
+      "ftpFormat": "SFTP",
+      "ftpConnMode": "Active"
+    },
+    "libEdiType": "31B/US-SAN",
+    "vendorEdiType": "31B/US-SAN"
+  },
+  "code": "SLM",
+  "name": "Soulman",
+  "urls": [],
+  "emails": [],
+  "status": "Active",
+  "aliases": [],
+  "isDonor": false,
+  "accounts": [
+    {
+      "name": "Corporate Account",
+      "accountNo": "AC789456",
+      "acqUnitIds": [],
+      "accountStatus": "Active"
+    },
+    {
+      "name": "Purchase Account",
+      "accountNo": "PA123654",
+      "acqUnitIds": [],
+      "accountStatus": "Pending"
+    }
+  ],
+  "contacts": [],
+  "isVendor": true,
+  "metadata": {
+    "createdDate": "2025-07-18T11:16:58.473Z",
+    "updatedDate": "2025-07-18T11:38:51.228Z",
+    "createdByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8",
+    "updatedByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8"
+  },
+  "addresses": [
+    {
+      "isPrimary": true,
+      "categories": [],
+      "addressLine1": "742 Maple Street",
+      "addressLine2": "Suite 300",
+      "city": "Austin",
+      "stateRegion": "TX",
+      "zipCode": "78701",
+      "country": "USA"
+    }
+  ],
+  "acqUnitIds": [],
+  "agreements": [],
+  "changelogs": [],
+  "interfaces": [],
+  "phoneNumbers": [],
+  "paymentMethod": "Credit Card",
+  "discountPercent": 10,
+  "vendorCurrencies": [
+    "USD",
+    "EUR",
+    "GBP"
+  ],
+  "organizationTypes": [],
+  "exportToAccounting": false,
+  "privilegedContacts": []
+}

--- a/src/main/resources/data/privileged-contacts-5.0.0/jas_privileged_contact.json
+++ b/src/main/resources/data/privileged-contacts-5.0.0/jas_privileged_contact.json
@@ -1,0 +1,57 @@
+{
+  "id": "b1b56c53-23a6-46f9-af2d-80921efcf84f",
+  "urls": [
+    {
+      "value": "https://james-foundation.org/staff/mcmillan",
+      "description": "Staff Profile",
+      "language": "eng",
+      "categories": [],
+      "isPrimary": true
+    }
+  ],
+  "emails": [
+    {
+      "value": "mina.mcmillan@james-foundation.org",
+      "description": "Work Email",
+      "isPrimary": true,
+      "categories": []
+    }
+  ],
+  "_version": 1,
+  "inactive": false,
+  "lastName": "Mcmillan",
+  "metadata": {
+    "createdDate": "2025-07-18T11:27:25.189Z",
+    "updatedDate": "2025-07-18T11:27:25.189Z",
+    "createdByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8",
+    "updatedByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8"
+  },
+  "addresses": [
+    {
+      "isPrimary": true,
+      "categories": [],
+      "addressLine1": "1234 Pine Avenue",
+      "addressLine2": "Floor 5",
+      "city": "Portland",
+      "stateRegion": "OR",
+      "zipCode": "97201",
+      "country": "USA"
+    }
+  ],
+  "firstName": "Mina",
+  "categories": [],
+  "phoneNumbers": [
+    {
+      "phoneNumber": "+1 (503) 555-0192",
+      "categories": [],
+      "isPrimary": true,
+      "language": "eng"
+    },
+    {
+      "phoneNumber": "+1 (503) 555-0193",
+      "categories": [],
+      "isPrimary": false,
+      "language": "eng"
+    }
+  ]
+}

--- a/src/main/resources/data/privileged-contacts-5.0.0/lop_privileged_contact.json
+++ b/src/main/resources/data/privileged-contacts-5.0.0/lop_privileged_contact.json
@@ -1,0 +1,43 @@
+{
+  "id": "f2b56c53-23a6-46f9-af2d-80921efcf85e",
+  "urls": [],
+  "emails": [
+    {
+      "value": "sarah.wilson@lopez-foundation.org",
+      "description": "Primary Email",
+      "isPrimary": true,
+      "categories": []
+    }
+  ],
+  "_version": 1,
+  "inactive": false,
+  "lastName": "Wilson",
+  "metadata": {
+    "createdDate": "2025-07-18T11:27:25.189Z",
+    "updatedDate": "2025-07-18T11:27:25.189Z",
+    "createdByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8",
+    "updatedByUserId": "ea703e33-d9eb-4ab0-bff0-3eb7e18ac4a8"
+  },
+  "addresses": [
+    {
+      "isPrimary": true,
+      "categories": [],
+      "addressLine1": "543 Elm Street",
+      "addressLine2": "Apt 7B",
+      "city": "Seattle",
+      "stateRegion": "WA",
+      "zipCode": "98101",
+      "country": "USA"
+    }
+  ],
+  "firstName": "Sarah",
+  "categories": [],
+  "phoneNumbers": [
+    {
+      "phoneNumber": "+1 (206) 555-0123",
+      "categories": [],
+      "isPrimary": true,
+      "language": "eng"
+    }
+  ]
+}

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -40,6 +40,7 @@ import io.vertx.core.json.JsonObject;
 
 @RunWith(JUnitPlatform.class)
 public class StorageTestSuite {
+
   private static final Logger logger = LogManager.getLogger(StorageTestSuite.class);
 
   private static Vertx vertx;
@@ -86,17 +87,14 @@ public class StorageTestSuite {
 
   @BeforeAll
   public static void before() throws InterruptedException, ExecutionException, TimeoutException {
-
     // tests expect English error messages only, no Danish/German/...
     Locale.setDefault(Locale.US);
     vertx = Vertx.vertx();
 
     logger.info("Start container database");
-
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
 
     DeploymentOptions options = new DeploymentOptions();
-
     options.setConfig(new JsonObject().put("http.port", port).put(HttpClientMock2.MOCK_MODE, "true"));
     startVerticle(options);
 
@@ -126,11 +124,9 @@ public class StorageTestSuite {
 
   private static void startVerticle(DeploymentOptions options)
     throws InterruptedException, ExecutionException, TimeoutException {
-
     logger.info("Start verticle");
 
     CompletableFuture<String> deploymentComplete = new CompletableFuture<>();
-
     vertx.deployVerticle(RestVerticle.class.getName(), options, res -> {
       if(res.succeeded()) {
         deploymentComplete.complete(res.result());

--- a/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
+++ b/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
@@ -6,6 +6,7 @@ import static org.folio.rest.utils.TenantApiTestUtil.postTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.purge;
 import static org.folio.rest.utils.TestEntities.ORGANIZATION;
+import static org.folio.rest.utils.TestEntities.PRIVILEGED_CONTACT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.Test;
 
 import io.restassured.http.Header;
 
-
 class TenantSampleDataTest extends TestBase {
 
   private final Logger logger = LogManager.getLogger(TenantSampleDataTest.class);
@@ -37,7 +37,6 @@ class TenantSampleDataTest extends TestBase {
   private static final Header MIGRATION_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, "migration");
   private static TenantJob tenantJob;
 
-
   @Test
   void sampleDataTests() throws MalformedURLException {
     try {
@@ -45,36 +44,28 @@ class TenantSampleDataTest extends TestBase {
       tenantJob = prepareTenant(ANOTHER_TENANT_HEADER, false, false);
       logger.info("-- upgrade the tenant with sample & reference data, so that it will be inserted now --");
       tenantJob = upgradeTenantWithDataLoad();
-      logger.info(
-          "-- upgrade the tenant again with no sample/reference data, so the previously inserted data stays in tact --");
+      logger.info("-- upgrade the tenant again with no sample/reference data, so the previously inserted data stays in tact --");
       tenantJob = upgradeTenantWithNoDataLoad();
-    }
-    finally {
+    } finally {
       deleteTenant(tenantJob ,ANOTHER_TENANT_HEADER);
     }
   }
 
-
   @Test
   void testPartialSampleDataLoading() throws MalformedURLException {
     logger.info("load sample date");
-
     try {
       TenantAttributes tenantAttributes = TenantApiTestUtil.prepareTenantBody(true, false);
       tenantJob = postTenant(PARTIAL_TENANT_HEADER, tenantAttributes);
-
       OrganizationCollection organizationCollection = getData(ORGANIZATION.getEndpoint(), PARTIAL_TENANT_HEADER).then()
         .extract()
         .response()
         .as(OrganizationCollection.class);
-
       for (Organization organization : organizationCollection.getOrganizations()) {
         deleteData(ORGANIZATION.getEndpointWithId(), organization.getId(), PARTIAL_TENANT_HEADER);
       }
-
       tenantAttributes = TenantApiTestUtil.prepareTenantBody(true, true);
       tenantJob = postTenant(PARTIAL_TENANT_HEADER, tenantAttributes);
-
       for (TestEntities entity : TestEntities.values()) {
         logger.info(TEST_EXPECTED_QUANTITY_FOR_ENTRY, entity.getInitialQuantity(), entity.name());
         verifyCollectionQuantity(entity.getEndpoint(), entity.getInitialQuantity(), PARTIAL_TENANT_HEADER);
@@ -84,20 +75,19 @@ class TenantSampleDataTest extends TestBase {
     }
   }
 
-
   @Test
-  void testLoadReferenceData() throws MalformedURLException {
+  void testLoadReferenceData() {
     logger.info("load only Reference Data");
     try {
       TenantAttributes tenantAttributes = TenantApiTestUtil.prepareTenantBody(false, true);
       tenantJob = postTenant(PARTIAL_TENANT_HEADER, tenantAttributes);
-
       for (TestEntities entity : TestEntities.values()) {
         if (entity.isReferenceData()) {
           verifyCollectionQuantity(entity.getEndpoint(), entity.getInitialQuantity(), PARTIAL_TENANT_HEADER);
         } else {
-          logger.info("Test sample data not loaded for " + entity.name());
-          verifyCollectionQuantity(entity.getEndpoint(), 0, PARTIAL_TENANT_HEADER);
+          logger.info("testLoadReferenceData:: Test sample data not loaded for {}", entity.name());
+          int expectedExistingReferenceQuantity = entity == PRIVILEGED_CONTACT ? 2 : entity == ORGANIZATION ? 7 : 0;
+          verifyCollectionQuantity(entity.getEndpoint(), expectedExistingReferenceQuantity, PARTIAL_TENANT_HEADER);
         }
       }
     } finally {
@@ -127,24 +117,21 @@ class TenantSampleDataTest extends TestBase {
     }
   }
 
-  private TenantJob upgradeTenantWithDataLoad() throws MalformedURLException {
-
+  private TenantJob upgradeTenantWithDataLoad() {
     logger.info("upgrading Module with sample and reference data");
     TenantAttributes tenantAttributes = TenantApiTestUtil.prepareTenantBody(true, true);
     tenantJob = postTenant(ANOTHER_TENANT_HEADER, tenantAttributes);
     for (TestEntities entity : TestEntities.values()) {
-      logger.info("Test expected quantity for " + entity.name());
+      logger.info("upgradeTenantWithDataLoad:: Test expected quantity for {}", entity.name());
       verifyCollectionQuantity(entity.getEndpoint(), entity.getInitialQuantity(), ANOTHER_TENANT_HEADER);
     }
     return tenantJob;
   }
 
   private TenantJob upgradeTenantWithNoDataLoad() throws MalformedURLException {
-
     logger.info("upgrading Module without sample data");
     TenantAttributes tenantAttributes = TenantApiTestUtil.prepareTenantBody(false, false);
     tenantJob = postTenant(ANOTHER_TENANT_HEADER, tenantAttributes);
-
     for(TestEntities te: TestEntities.values()) {
       verifyCollectionQuantity(te.getEndpoint(), te.getInitialQuantity(), ANOTHER_TENANT_HEADER);
     }
@@ -158,16 +145,13 @@ class TenantSampleDataTest extends TestBase {
     try {
       // RMB-331 the case if older version has no db schema
       postTenant(NONEXISTENT_TENANT_HEADER, tenantAttributes);
-
       // Check that no sample data loaded
       for (TestEntities entity : TestEntities.values()) {
         logger.info(TEST_EXPECTED_QUANTITY_FOR_ENTRY, 0, entity.name());
         verifyCollectionQuantity(entity.getEndpoint(), 0, NONEXISTENT_TENANT_HEADER);
       }
-    }
-    finally {
+    } finally {
       purge(NONEXISTENT_TENANT_HEADER);
     }
   }
-
 }

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -18,6 +18,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.config.ApplicationConfig;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
@@ -38,6 +40,8 @@ import io.vertx.core.json.JsonObject;
  * IDE during development.
  */
 public abstract class TestBase {
+
+  private final Logger logger = LogManager.getLogger(TestBase.class);
 
   static final String NON_EXISTED_ID = "bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa";
   private static final String TENANT_NAME = "diku";
@@ -70,13 +74,13 @@ public abstract class TestBase {
   }
 
   void verifyCollectionQuantity(String endpoint, int quantity, Header tenantHeader) {
+    logger.info("verifyCollectionQuantity:: Endpoint: {}, expected quantity: {}", endpoint, quantity);
     getData(endpoint, tenantHeader)
       .then()
       .log().all()
       .statusCode(200)
       .body("totalRecords", equalTo(quantity));
   }
-
 
   void verifyCollectionQuantity(String endpoint, int quantity) throws MalformedURLException {
     // Verify that there are no existing  records
@@ -103,14 +107,6 @@ public abstract class TestBase {
   Response getDataById(String endpoint, String id) throws MalformedURLException {
     return given()
       .pathParam("id", id)
-      .header(TENANT_HEADER)
-      .contentType(ContentType.JSON)
-      .get(storageUrl(endpoint));
-  }
-
-  Response getDataByParam(String endpoint, Map<String, Object> params) throws MalformedURLException {
-    return given()
-      .params(params)
       .header(TENANT_HEADER)
       .contentType(ContentType.JSON)
       .get(storageUrl(endpoint));
@@ -234,5 +230,4 @@ public abstract class TestBase {
         list ->
           list.isEmpty() ? Future.succeededFuture() : Future.failedFuture(failureMessage));
   }
-
 }

--- a/src/test/java/org/folio/rest/utils/TestEntities.java
+++ b/src/test/java/org/folio/rest/utils/TestEntities.java
@@ -9,11 +9,18 @@ import org.folio.rest.jaxrs.model.OrganizationType;
 public enum TestEntities {
   CATEGORY("/organizations-storage/categories", Category.class, "category.sample", "value", "AccountingServices", 4, true),
   CONTACT("/organizations-storage/contacts", Contact.class, "contact.sample", "notes", "ABC123", 13, false),
-  PRIVILEGED_CONTACT("/organizations-storage/privileged-contacts", Contact.class, "contact.sample", "notes", "ABC123", 0, false),
+  PRIVILEGED_CONTACT("/organizations-storage/privileged-contacts", Contact.class, "contact.sample", "notes", "ABC123", 2, false),
   INTERFACE("/organizations-storage/interfaces", Interface.class, "interface.sample", "name", "Test Portal", 13, false),
-  ORGANIZATION("/organizations-storage/organizations", Organization.class, "organization.sample", "code", "ABC123", 16, false),
+  ORGANIZATION("/organizations-storage/organizations", Organization.class, "organization.sample", "code", "ABC123", 23, false),
   ORGANIZATION_TYPE("/organizations-storage/organization-types", OrganizationType.class, "organization_type.sample", "status", "Inactive", 4, true);
 
+  private final int initialQuantity;
+  private final String endpoint;
+  private final String sampleFileName;
+  private final String updatedFieldName;
+  private final Object updatedFieldValue;
+  private final boolean isReferenceData;
+  private final Class<?> clazz;
 
   TestEntities(String endpoint, Class<?> clazz, String sampleFileName, String updatedFieldName, String updatedFieldValue, int initialQuantity, boolean isReferenceData) {
     this.endpoint = endpoint;
@@ -24,14 +31,6 @@ public enum TestEntities {
     this.initialQuantity = initialQuantity;
     this.isReferenceData = isReferenceData;
   }
-
-  private int initialQuantity;
-  private String endpoint;
-  private String sampleFileName;
-  private String updatedFieldName;
-  private Object updatedFieldValue;
-  private boolean isReferenceData;
-  private Class<?> clazz;
 
   public String getEndpoint() {
     return endpoint;

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,11 +1,11 @@
-status = debug
+status = info
 name = PropertiesConfig
 packages = org.folio.okapi.common.logging
 
 filters = threshold
 
 filter.threshold.type = ThresholdFilter
-filter.threshold.level = debug
+filter.threshold.level = info
 
 appenders = console
 
@@ -14,6 +14,6 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{ISO8601} %-5p [%-22t] %c{1} %m%n
 
-rootLogger.level = debug
+rootLogger.level = info
 rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
### **Purpose**

- <https://folio-org.atlassian.net/browse/MODORG-84>

### **Approach**

- Add 5 vendor organizations (CAC, GLD, GNT, QCO, SLM)
- Add 2 donor organizations (JAS and LOP)
- Add 1 privileged contact per each donor organization
- Update and clean tests classes and remove invalid log markers and some deprecated methods
- Test manually using the reinstall endpoint on mgr-tenant-entitlement & eureka-cli with a deployed ECS profile

```bash
curl --location 'http://localhost:8000/reinstall/modules?tenantParameters=loadReference%3Dtrue%2CloadSample%3Dtrue' \
--header 'Content-Type: application/json' \
--data '{
  "tenantId": "7e90d843-7b93-4e5c-b554-0608a47e0e6f",
  "applicationId": "app-ecs-1.0.0",
  "modules": [
    "mod-organizations-storage-5.0.0-SNAPSHOT.124"
  ]
}'
```

> Uses `ecs` central tenant, but works the same with other member tenants

<img width="1611" height="1104" alt="image" src="https://github.com/user-attachments/assets/982020bf-92b1-4ef2-889b-62d10d520f3f" />

> Loaded Vendor and Donor Organizations

<img width="1686" height="948" alt="image" src="https://github.com/user-attachments/assets/a7f3f6d4-c509-4570-9706-accc90c98972" />

> Loaded Privileged Contacts
