### PR TITLE
Remove create internal_lock table

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -33,11 +33,6 @@
     },
     {
       "run": "after",
-      "snippetPath": "tables/create_internal_lock_table.sql",
-      "fromModuleVersion": "mod-organizations-storage-4.9.0"
-    },
-    {
-      "run": "after",
       "snippetPath": "migration/uuid_categories.ftl",
       "fromModuleVersion": "mod-organizations-storage-5.0.0"
     },

--- a/src/main/resources/templates/db_scripts/tables/create_internal_lock_table.sql
+++ b/src/main/resources/templates/db_scripts/tables/create_internal_lock_table.sql
@@ -1,5 +1,0 @@
-CREATE TABLE IF NOT EXISTS internal_lock (
-  lock_name text NOT NULL PRIMARY KEY
-);
-
-INSERT INTO internal_lock(lock_name) VALUES ('audit_outbox') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
### **Purpose**

- Remove create `internal_lock` table

### **Approach**

- The command was always creating the now redundant table
- The proposed changes will avoid the creation of `internal_lock` table on fresh installs
